### PR TITLE
Adding mentions to page metadata

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -51,6 +51,26 @@ module Jekyll
       end
       # rubocop:enable Metrics/AbcSize
 
+      # Public: Find al lthe mentions in the doc and add it to
+      # doc.data['mentions']
+      def pre_render(doc)
+        found_mentions = doc.content.scan(/\s@(\w+)/)
+        if found_mentions.empty?
+          return
+        end
+
+        mentions = doc.data['mentions']
+        if mentions == nil
+          mentions = []
+        end
+
+        for mention in found_mentions
+          mentions.append(mention[0]) unless mentions.include?(mention[0])
+        end
+
+        doc.data['mentions'] = mentions
+      end
+
       # Public: Create or fetch the filter for the given {{src}} base URL.
       #
       # src - the base URL (e.g. https://github.com)
@@ -74,7 +94,7 @@ module Jekyll
 
       # Public: Calculate the base URL to use for mentioning.
       #
-      # The custom base URL can be defined in either the site config or a document's
+      # The custom base URL can be defined \in either the site config or a document's
       # front matter as `jekyll-mentions.base_url` or `jekyll-mentions`, and must be
       # a valid URL (i.e. it must include a protocol and valid domain).
       # It should _not_ have a trailing slash.
@@ -137,4 +157,8 @@ end
 
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   Jekyll::Mentions.mentionify(doc) if Jekyll::Mentions.mentionable?(doc)
+end
+
+Jekyll::Hooks.register [:posts, :pages, :documents], :pre_render do |doc|
+  Jekyll::Mentions.pre_render(doc)
 end


### PR DESCRIPTION
With this Pull Request, the mentioned are added to metadata for each page called `mentions`. This can be used like tags.